### PR TITLE
Feature/deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ An app configured with `"app": "s3"` will run using files on S3. QASM jobs that 
 - ``"bucket": <string>``
     - Name of the s3 bucket from which to pull data (only required for ``"app": "s3"``)
 
+- ``"intercept_s3_protocol": <boolean>``
+    - (Optional) Whether to intercept s3:// protocol links and open them in the S3 Browser component. Will only work if ``true`` and if the app is running in ``"app": "s3"`` mode.
+
 - ``"static_site_bucket": <string>``
     - (Optional) Name of the s3 bucket to which to upload the static website (only required to run ``npm run qasm-push``)
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,18 @@ An app configured with `"app": "s3"` will run using files on S3. QASM jobs that 
 - ``"bucket": <string>``
     - Name of the s3 bucket from which to pull data (only required for ``"app": "s3"``)
 
-- ``"intercept_s3_protocol": <boolean>``
-    - (Optional) Whether to intercept s3:// protocol links and open them in the S3 Browser component. Will only work if ``true`` and if the app is running in ``"app": "s3"`` mode.
+- ``"intercept_s3_protocol": <Array>``
+    - (Optional) Only availible for ``"app": "s3"`` mode. When present, clicking/navigating to a link that starts with ``"s3://"`` will open a prompt to open the link in the app instead. The value in the config should be a list of component names, as shown in the example below. The first component in the list will be the default handler for s3 links, *except* when another component in the list is currently open. For example, if the ``"grid"`` screen is open, it will handle all s3 links, even though ``"imagelabeler"`` is listed first in the list. Example:
+    ```js
+    "intercept_s3_protocol": [
+        "imagelabeler",
+        "grid"
+    ]
+    ```
+    - Components that currently have special s3 protocol functionality are as follows:
+        - ``"imagelabeler"``: If the s3 link points to an image, the image will be loaded into the imagelabeler component. If the s3 link points to a json file, the file will be loaded as an annotation. If the s3 link points to a directory, the user will be prompted to select if it should be loaded as the image or annotation directory.
+        - ``"grid"``: If the s3 link points to an json file, the file will be loaded as a labels file. If the s3 link points to a directory, the directory will be used as the image directory and the images will be loaded.
+        - ``"multiclassgrid"``: Same as ``"grid"``
 
 - ``"static_site_bucket": <string>``
     - (Optional) Name of the s3 bucket to which to upload the static website (only required to run ``npm run qasm-push``)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ An app configured with `"app": "s3"` will run using files on S3. QASM jobs that 
     - Name of the s3 bucket from which to pull data (only required for ``"app": "s3"``)
 
 - ``"intercept_s3_protocol": <Array>``
-    - (Optional) Only availible for ``"app": "s3"`` mode. When present, clicking/navigating to a link that starts with ``"s3://"`` will open a prompt to open the link in the app instead. The value in the config should be a list of component names, as shown in the example below. The first component in the list will be the default handler for s3 links, *except* when another component in the list is currently open. For example, if the ``"grid"`` screen is open, it will handle all s3 links, even though ``"imagelabeler"`` is listed first in the list. Example:
+    - (Optional) When present, clicking/navigating to a link that starts with ``"s3://"`` will open a prompt to open the link in the app instead. The value in the config should be a list of component names, as shown in the example below. The first component in the list will be the default handler for s3 links, *except* when another component in the list is currently open. For example, if the ``"grid"`` screen is open, it will handle all s3 links, even though ``"imagelabeler"`` is listed first in the list. Only availible for ``"app": "s3"`` mode, and not supported for static website deployments. 
     ```js
     "intercept_s3_protocol": [
         "imagelabeler",
@@ -95,6 +95,7 @@ An app configured with `"app": "s3"` will run using files on S3. QASM jobs that 
         - ``"imagelabeler"``: If the s3 link points to an image, the image will be loaded into the imagelabeler component. If the s3 link points to a json file, the file will be loaded as an annotation. If the s3 link points to a directory, the user will be prompted to select if it should be loaded as the image or annotation directory.
         - ``"grid"``: If the s3 link points to an json file, the file will be loaded as a labels file. If the s3 link points to a directory, the directory will be used as the image directory and the images will be loaded.
         - ``"multiclassgrid"``: Same as ``"grid"``
+    - For packaged (.exe) instances of the app, the protocol will be active upon install, and will open the app even if it is not currently running. If multiple apps are installed with the s3 protocol active, than only the first one installed will use the protocol. The protocol interception will be removed after uninstalling the app using the packaged uninstaller, after which a new installation will need to be performed to re-enable the protocol.
 
 - ``"static_site_bucket": <string>``
     - (Optional) Name of the s3 bucket to which to upload the static website (only required to run ``npm run qasm-push``)

--- a/react-frontend/.gitignore
+++ b/react-frontend/.gitignore
@@ -20,6 +20,7 @@
 
 # Active config
 config.json
+public/config-dup.json
 
 # User configs
 /configs/*

--- a/react-frontend/QASM.py
+++ b/react-frontend/QASM.py
@@ -102,19 +102,24 @@ def main():
             f.write(str(soup))
             f.truncate()
 
+    app = config["app"]
     # Intercept s3 protocol
     if INTERCEPT_S3_PROTOCOL_KEY in config and config[INTERCEPT_S3_PROTOCOL_KEY]:
-        with open(PACKAGE_JSON_PATH, "r+") as f:
-            package_json = json.load(f)
-            package_json["build"]["protocols"] = {
-                "name": "S3 Protocol",
-                "schemes": ["s3"]
-            }
-            f.seek(0)
-            json.dump(package_json, f, indent=2)
-            f.truncate()
+        # Only valid for s3 mode
+        if app == "s3":
+            with open(PACKAGE_JSON_PATH, "r+") as f:
+                package_json = json.load(f)
+                package_json["build"]["protocols"] = {
+                    "name": "S3 Protocol",
+                    "schemes": ["s3"]
+                }
+                f.seek(0)
+                json.dump(package_json, f, indent=2)
+                f.truncate()
+        else:
+            print(f"WARNING: {INTERCEPT_S3_PROTOCOL_KEY} is only valid for 's3' app mode, ignoring...")
     
-    app = config["app"]
+    
     if (app in QASM_MODES):
         if (app == "s3" and any(key not in config for key in REQUIRED_S3_KEYS)):
             raise ValueError(f"Missing required key(s) for {app} app: {REQUIRED_S3_KEYS}")

--- a/react-frontend/QASM.py
+++ b/react-frontend/QASM.py
@@ -14,10 +14,12 @@ QASM_COMPONENTS = ["home", "grid", "multiclassgrid", "binaryeditor", "imagelabel
 QASM_MODES = ["local", "s3"]
 RUN_MODES = ["dev", "build-exe", "push"]
 APP_NAME_KEY = "name"
+INTERCEPT_S3_PROTOCOL_KEY = "intercept_s3_protocol"
 PACKAGE_JSON_PATH = "./package.json"
 DEFAULT_INDEX_PATH = "./public/default-index.html"
 INDEX_PATH = "./public/index.html"
 CONFIG_DEST_PATH = "./config.json"
+CONFIG_DUP_PATH = "./public/config-dup.json"
 DEFAULT_CONFIG_PATH = "./default-config.json"
 
 def main():
@@ -47,9 +49,10 @@ def main():
             with open(args.config_path, "r") as f:
                 config = json.load(f)
         
-        # Save to the config path that the app will use
-        with open(CONFIG_DEST_PATH, "w") as f:
-            json.dump(config, f, indent=4)
+        # Save to the config paths that the app will use
+        for path in [CONFIG_DEST_PATH, CONFIG_DUP_PATH]:
+            with open(path, "w") as f:
+                json.dump(config, f, indent=4)
     except Exception as e:
         print(f"Error loading configuration json, aborting...")
         print(e)
@@ -82,6 +85,9 @@ def main():
             package_json = json.load(f)
             package_json["name"] = name.lower().replace(" ", "-") # Lowercase, no whitespace for package name
             package_json["build"]["productName"] = name # Windows application name
+            # Remove s3 protocol if it exists, we'll add it back later if needed
+            if "protocols" in package_json["build"]:
+                del package_json["build"]["protocols"]
             f.seek(0)
             json.dump(package_json, f, indent=2)
             f.truncate()
@@ -94,6 +100,18 @@ def main():
             soup.title.string = name # Name displayed in app header
             f.seek(0)
             f.write(str(soup))
+            f.truncate()
+
+    # Intercept s3 protocol
+    if INTERCEPT_S3_PROTOCOL_KEY in config and config[INTERCEPT_S3_PROTOCOL_KEY]:
+        with open(PACKAGE_JSON_PATH, "r+") as f:
+            package_json = json.load(f)
+            package_json["build"]["protocols"] = {
+                "name": "S3 Protocol",
+                "schemes": ["s3"]
+            }
+            f.seek(0)
+            json.dump(package_json, f, indent=2)
             f.truncate()
     
     app = config["app"]

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "qasm-demo",
-  "version": "0.18.2",
+  "name": "deep-links",
+  "version": "0.19.0",
   "private": true,
   "proxy": "http://localhost:3000",
   "homepage": "./",
@@ -63,7 +63,7 @@
     ]
   },
   "build": {
-    "productName": "QASM Demo",
+    "productName": "Deep Links",
     "win": {
       "target": "NSIS",
       "icon": "public/icon.png"
@@ -71,6 +71,12 @@
     "mac": {
       "target": "dmg",
       "icon": "public/icon.png"
+    },
+    "protocols": {
+      "name": "S3 Protocol",
+      "schemes": [
+        "s3"
+      ]
     }
   }
 }

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -1,5 +1,20 @@
 {
-  "name": "deep-links",
+  "name": "qasm-demo",
+  "author": {
+    "name": "Trevor Burgoyne",
+    "url": "https://github.com/TrevorBurgoyne"
+  },
+  "contributors": [
+    {
+      "name": "Carter Solberg",
+      "url": "https://github.com/csolbs24"
+    },
+    {
+      "name": "Josh Dean",
+      "url": "https://github.com/joshua-dean"
+    }
+  ],
+  "description": "A web application built on React and Electron, for running custom QA and labeling jobs from a local host, a packaged windows .exe, or a statically hosted S3 website.",
   "version": "0.19.0",
   "private": true,
   "proxy": "http://localhost:3000",
@@ -63,7 +78,7 @@
     ]
   },
   "build": {
-    "productName": "Deep Links",
+    "productName": "QASM Demo",
     "win": {
       "target": "NSIS",
       "icon": "public/icon.png"
@@ -77,12 +92,6 @@
     "mac": {
       "target": "dmg",
       "icon": "public/icon.png"
-    },
-    "protocols": {
-      "name": "S3 Protocol",
-      "schemes": [
-        "s3"
-      ]
     }
   }
 }

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -68,6 +68,12 @@
       "target": "NSIS",
       "icon": "public/icon.png"
     },
+    "nsis": {
+      "runAfterFinish": true,
+      "createDesktopShortcut": true,
+      "deleteAppDataOnUninstall": true,
+      "include": "uninstaller.nsh"
+    },
     "mac": {
       "target": "dmg",
       "icon": "public/icon.png"

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -74,8 +74,7 @@ exports.openDeepLink = async (config, mainWindow, deep_link)  => {
                 file_name = ret.file_name.split(".")[0];
                 mainWindow.webContents.executeJavaScript(`window.COMPONENT.image_dir = decodeURI("${start_folder}"); window.COMPONENT.QASM.s3_bucket = decodeURI("${bucket_name}"); window.COMPONENT.loadImageDir("${file_name}");`);
             } else {
-                // TODO: prompt user to select anno dir or image dir
-                break;
+                mainWindow.webContents.executeJavaScript(`window.COMPONENT.selectDirType(decodeURI("${start_folder}"), decodeURI("${bucket_name}"));`);
             }
             break;
         default:

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -104,7 +104,3 @@ function isJsonFile(path) {
 function isImageFile(path) {
     return path.slice(-3) in image_types;
 }
-
-
-
-

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -23,7 +23,11 @@ exports.openDeepLink = async (config, mainWindow, deep_link)  => {
     // If the active component is not in the user-specified list,
     // then default to the first component in the list
     if (!config.intercept_s3_protocol.includes(active_component)) {
-        active_component = config.intercept_s3_protocol[0]
+        active_component = config.intercept_s3_protocol[0];
+        // Click on router link to change to the component
+        mainWindow.webContents.executeJavaScript(`document.getElementById("${active_component}-link").click();`);
+        // Wait for the component to load
+        await mainWindow.webContents.executeJavaScript(`window.COMPONENT.props.component === "${active_component}"`);
     }
 
     switch (active_component) {

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -16,9 +16,19 @@ exports.openDeepLink = async (config, mainWindow, deep_link)  => {
     // get the rest of the path, which is the folder name
     let start_folder = s3_path.slice(bucket_name.length + 1);
 
-    // open an s3 browser window
-    let active_component = await mainWindow.webContents.executeJavaScript("window.COMPONENT.props.component");
-    mainWindow.webContents.executeJavaScript(`console.log("${active_component}");`)
+    // get the active component
+    let awaiting_response = true
+    let active_component;
+    while (awaiting_response) {
+        try {
+            active_component = await mainWindow.webContents.executeJavaScript("window.COMPONENT.props.component");
+            mainWindow.webContents.executeJavaScript(`console.log("${active_component}");`)
+            awaiting_response = false
+        } catch (error) {
+            // wait 1 second
+            await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+    }
 
     // If the active component is not in the user-specified list,
     // then default to the first component in the list

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -54,7 +54,7 @@ exports.openDeepLink = async (config, mainWindow, deep_link)  => {
                 start_folder = ret.folder;
                 mainWindow.webContents.executeJavaScript(`console.log(decodeURI("${start_folder}")); window.COMPONENT.loadLabels(window, window.COMPONENT, ["${file_name}"], decodeURI("${start_folder}"));`);
             } else {
-                mainWindow.webContents.executeJavaScript(`window.COMPONENT.selectImageDir(window, window.COMPONENT, decodeURI("${start_folder}"), decodeURI("${bucket_name}"));`);
+                mainWindow.webContents.executeJavaScript(`window.COMPONENT.src = decodeURI("${start_folder}"); window.COMPONENT.loadImageDir(window, window.COMPONENT, decodeURI("${bucket_name}"));`);
             }
             break;
         case components.IMAGE_LABELER:

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -1,0 +1,64 @@
+// Utils for handling deep links
+const { s3_protocol, components } = require("./electron_constants.js");
+
+/**
+ * Open a deep link.
+ * 
+ * @param {Object} config config object
+ * @param {Object} mainWindow electron BrowserWindow object
+ * @param {string} deep_link full deep link, 's3://<bucket-name>/<s3_key>'
+ */
+exports.openDeepLink = async (config, mainWindow, deep_link)  => {
+    // remove s3 and the '://'
+    let s3_path = deep_link.slice(s3_protocol.length + "://".length); 
+    // get the first part of the path, which is the bucket name
+    let bucket_name = s3_path.split("/")[0];
+    // get the rest of the path, which is the folder name
+    let start_folder = s3_path.slice(bucket_name.length + 1);
+
+    // open an s3 browser window
+    let active_component = await mainWindow.webContents.executeJavaScript("window.COMPONENT.props.component");
+    mainWindow.webContents.executeJavaScript(`console.log("${active_component}");`)
+
+    // If the active component is not in the user-specified list,
+    // then default to the first component in the list
+    if (!config.intercept_s3_protocol.includes(active_component)) {
+        active_component = config.intercept_s3_protocol[0]
+    }
+
+    switch (active_component) {
+        case components.GRID:
+        case components.MULTI_CLASS_GRID:
+            // For grids, if the path is a json file, then load the labels
+            // Otherwise, we open a directory select dialog
+            if (isJsonFile(start_folder)) {
+                // separate file name and folder
+                let file_name = start_folder.split("/").slice(-1)[0];
+                start_folder = start_folder.replace(file_name, "");
+                mainWindow.webContents.executeJavaScript(`console.log(decodeURI("${start_folder}")); window.COMPONENT.loadLabels(window, window.COMPONENT, ["${file_name}"], decodeURI("${start_folder}"));`);
+            } else {
+                mainWindow.webContents.executeJavaScript(`window.COMPONENT.src = decodeURI("${start_folder}"); console.log(window.COMPONENT.src); window.COMPONENT.selectImageDir(window, window.COMPONENT);`);
+            }
+            break;
+        case components.IMAGE_LABELER:
+            break;
+        default:
+            break;
+    }
+    // mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
+};
+
+
+/**
+ * Check if a path is a json file.
+ * 
+ * @param {string} path path to check
+ * @returns {boolean} true if path is a json file, false otherwise
+ */
+function isJsonFile(path) {
+    return path.slice(-5).toLowerCase() === ".json";
+}
+
+
+
+

--- a/react-frontend/public/deep_link_utils.js
+++ b/react-frontend/public/deep_link_utils.js
@@ -51,7 +51,7 @@ exports.openDeepLink = async (config, mainWindow, deep_link)  => {
                 start_folder = start_folder.replace(file_name, "");
                 mainWindow.webContents.executeJavaScript(`console.log(decodeURI("${start_folder}")); window.COMPONENT.loadLabels(window, window.COMPONENT, ["${file_name}"], decodeURI("${start_folder}"));`);
             } else {
-                mainWindow.webContents.executeJavaScript(`window.COMPONENT.src = decodeURI("${start_folder}"); console.log(window.COMPONENT.src); window.COMPONENT.selectImageDir(window, window.COMPONENT);`);
+                mainWindow.webContents.executeJavaScript(`window.COMPONENT.selectImageDir(window, window.COMPONENT, decodeURI("${start_folder}"), decodeURI("${bucket_name}"));`);
             }
             break;
         case components.IMAGE_LABELER:

--- a/react-frontend/public/electron.js
+++ b/react-frontend/public/electron.js
@@ -1,6 +1,7 @@
 // Electron desktop application
 const path = require("path");
 const electron_utils = require("./electron_utils.js");
+const { s3_browser_modes } = require("../src/QASM/constants.js");
 const { app, BrowserWindow, dialog } = require("electron");
 const isDev = require("electron-is-dev");
 const s3_protocol = "s3" // followed by '://', e.g. 's3://'
@@ -26,7 +27,7 @@ function openDeepLink(mainWindow, deep_link) {
   let start_folder = s3_path.slice(bucket_name.length + 1);
 
   // open an s3 browser window
-  mainWindow.webContents.executeJavaScript(`let popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "select_directory"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
+  mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
 }
 
 if (!gotTheLock) {

--- a/react-frontend/public/electron.js
+++ b/react-frontend/public/electron.js
@@ -1,49 +1,62 @@
 // Electron desktop application
+const fs = require('fs')
 const path = require("path");
 const electron_utils = require("./electron_utils.js");
 const { s3_browser_modes } = require("../src/QASM/constants.js");
-const { app, BrowserWindow, dialog } = require("electron");
+const { app, BrowserWindow } = require("electron");
 const isDev = require("electron-is-dev");
 const s3_protocol = "s3" // followed by '://', e.g. 's3://'
-
-// https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
-if (process.defaultApp) {
-  if (process.argv.length >= 2) {
-    app.setAsDefaultProtocolClient(s3_protocol, process.execPath, [path.resolve(process.argv[1])])
-  }
-} else {
-  app.setAsDefaultProtocolClient(s3_protocol)
-}
-
-const gotTheLock = app.requestSingleInstanceLock()
 let mainWindow
 
-function openDeepLink(mainWindow, deep_link) {
-  // remove s3 and the '://'
-  let s3_path = deep_link.slice(s3_protocol.length + "://".length); 
-  // get the first part of the path, which is the bucket name
-  let bucket_name = s3_path.split("/")[0];
-  // get the rest of the path, which is the folder name
-  let start_folder = s3_path.slice(bucket_name.length + 1);
-
-  // open an s3 browser window
-  mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
-}
-
-if (!gotTheLock) {
-  app.quit()
-} else {
-  app.on('second-instance', (event, commandLine) => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
-
-      // open the deep link in a new window using s3 browser
-      let deep_link = commandLine.pop().slice(0, -1); // full url with s3:// prefix
-      openDeepLink(mainWindow, deep_link);
+// Only intercept s3 protocol if specified in config
+let config = JSON.parse(fs.readFileSync(path.resolve(__dirname,"../config.json"), "utf-8"));
+if ("intercept_s3_protocol" in config && config.intercept_s3_protocol) {
+  // https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(s3_protocol, process.execPath, [path.resolve(process.argv[1])])
     }
-  })
+  } else {
+    app.setAsDefaultProtocolClient(s3_protocol)
+  }
+  const gotTheLock = app.requestSingleInstanceLock()
+
+  function openDeepLink(mainWindow, deep_link) {
+    // remove s3 and the '://'
+    let s3_path = deep_link.slice(s3_protocol.length + "://".length); 
+    // get the first part of the path, which is the bucket name
+    let bucket_name = s3_path.split("/")[0];
+    // get the rest of the path, which is the folder name
+    let start_folder = s3_path.slice(bucket_name.length + 1);
+
+    // open an s3 browser window
+    mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
+  }
+
+  if (!gotTheLock) {
+    app.quit()
+  } else {
+    app.on('second-instance', (event, commandLine) => {
+      // Someone tried to run a second instance, we should focus our window.
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore()
+        mainWindow.focus()
+
+        // open the deep link in a new window using s3 browser
+        let deep_link = commandLine.pop().slice(0, -1); // full url with s3:// prefix
+        openDeepLink(mainWindow, deep_link);
+      }
+    })
+  }
+} else {
+  // remove as default protocol client
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.removeAsDefaultProtocolClient(s3_protocol, process.execPath, [path.resolve(process.argv[1])])
+    }
+  } else {
+    app.removeAsDefaultProtocolClient(s3_protocol)
+  }
 }
 
 function createWindow() {

--- a/react-frontend/public/electron.js
+++ b/react-frontend/public/electron.js
@@ -2,11 +2,22 @@
 const fs = require('fs')
 const path = require("path");
 const electron_utils = require("./electron_utils.js");
-const { s3_browser_modes } = require("../src/QASM/constants.js");
-const { app, BrowserWindow } = require("electron");
+const { s3_browser_modes } = require("./electron_constants.js");
+const { app, BrowserWindow, dialog } = require("electron");
 const isDev = require("electron-is-dev");
 const s3_protocol = "s3" // followed by '://', e.g. 's3://'
-let mainWindow
+
+function openDeepLink(mainWindow, deep_link) {
+  // remove s3 and the '://'
+  let s3_path = deep_link.slice(s3_protocol.length + "://".length); 
+  // get the first part of the path, which is the bucket name
+  let bucket_name = s3_path.split("/")[0];
+  // get the rest of the path, which is the folder name
+  let start_folder = s3_path.slice(bucket_name.length + 1);
+
+  // open an s3 browser window
+  mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
+}
 
 // Only intercept s3 protocol if specified in config
 let config = JSON.parse(fs.readFileSync(path.resolve(__dirname,"../config.json"), "utf-8"));
@@ -19,35 +30,6 @@ if ("intercept_s3_protocol" in config && config.intercept_s3_protocol) {
   } else {
     app.setAsDefaultProtocolClient(s3_protocol)
   }
-  const gotTheLock = app.requestSingleInstanceLock()
-
-  function openDeepLink(mainWindow, deep_link) {
-    // remove s3 and the '://'
-    let s3_path = deep_link.slice(s3_protocol.length + "://".length); 
-    // get the first part of the path, which is the bucket name
-    let bucket_name = s3_path.split("/")[0];
-    // get the rest of the path, which is the folder name
-    let start_folder = s3_path.slice(bucket_name.length + 1);
-
-    // open an s3 browser window
-    mainWindow.webContents.executeJavaScript(`try{let popup}catch{}; popup = window.open(window.location.href, "S3 Browser"); popup.window.S3_BROWSER_MODE = "${s3_browser_modes.DEEP_LINK}"; popup.window.START_FOLDER = decodeURI("${start_folder}"); popup.window.BUCKET_NAME = decodeURI("${bucket_name}");`)
-  }
-
-  if (!gotTheLock) {
-    app.quit()
-  } else {
-    app.on('second-instance', (event, commandLine) => {
-      // Someone tried to run a second instance, we should focus our window.
-      if (mainWindow) {
-        if (mainWindow.isMinimized()) mainWindow.restore()
-        mainWindow.focus()
-
-        // open the deep link in a new window using s3 browser
-        let deep_link = commandLine.pop().slice(0, -1); // full url with s3:// prefix
-        openDeepLink(mainWindow, deep_link);
-      }
-    })
-  }
 } else {
   // remove as default protocol client
   if (process.defaultApp) {
@@ -58,10 +40,56 @@ if ("intercept_s3_protocol" in config && config.intercept_s3_protocol) {
     app.removeAsDefaultProtocolClient(s3_protocol)
   }
 }
+  
+const gotTheLock = app.requestSingleInstanceLock()
+
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', (event, commandLine) => {
+    // Someone tried to run a second instance, we should focus our window.
+    let mainWindow = BrowserWindow.getAllWindows()[0];
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+
+      // open the deep link in a new window using s3 browser
+      let deep_link = commandLine.pop(); // full url with s3:// prefix
+      dialog.showMessageBox(mainWindow, {type: "info", message: `Opening ${deep_link} in a new window.`});
+      openDeepLink(mainWindow, deep_link);
+    }
+  })
+  // app.on("open-url", (event, url) => {
+  //   event.preventDefault();
+  //   let mainWindow = BrowserWindow.getAllWindows()[0];
+  //   if (mainWindow) {
+  //     mainWindow.focus();
+  //   } else {
+  //     createWindow();
+  //     mainWindow = BrowserWindow.getAllWindows()[0];
+  //   }
+  //   // open the deep link in a new window using s3 browser
+  //   let deep_link = url.pop(); // full url with s3:// prefix
+  //   dialog.showMessageBox(mainWindow, {type: "info", message: `Opening ${url} in a new window.`});
+  //   openDeepLink(mainWindow, deep_link);
+  // });
+
+  // placed after open-url handler just in case and use another ready event handler
+  // app.on("ready", () => {
+  //   electron_utils.init_ipc_handlers();
+  //   createWindow();
+  // });
+
+  // Start app once electron has initialized
+  // app.whenReady().then(() => {
+  //   electron_utils.init_ipc_handlers();
+  //   createWindow();    
+  // });
+}
 
 function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({
+  let mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     icon: path.join(__dirname, "icon.ico"),

--- a/react-frontend/public/electron.js
+++ b/react-frontend/public/electron.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require("path");
 const electron_utils = require("./electron_utils.js");
 const { s3_browser_modes } = require("./electron_constants.js");
-const { app, BrowserWindow, dialog } = require("electron");
+const { app, BrowserWindow } = require("electron");
 const isDev = require("electron-is-dev");
 const s3_protocol = "s3" // followed by '://', e.g. 's3://'
 
@@ -20,7 +20,7 @@ function openDeepLink(mainWindow, deep_link) {
 }
 
 // Only intercept s3 protocol if specified in config
-let config = JSON.parse(fs.readFileSync(path.resolve(__dirname,"../config.json"), "utf-8"));
+let config = JSON.parse(fs.readFileSync(path.resolve(__dirname,"./config-dup.json"), "utf-8"));
 if ("intercept_s3_protocol" in config && config.intercept_s3_protocol) {
   // https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
   if (process.defaultApp) {
@@ -53,38 +53,11 @@ if (!gotTheLock) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
 
-      // open the deep link in a new window using s3 browser
+      // This handles opening a deep link when the app is already running
       let deep_link = commandLine.pop(); // full url with s3:// prefix
-      dialog.showMessageBox(mainWindow, {type: "info", message: `Opening ${deep_link} in a new window.`});
       openDeepLink(mainWindow, deep_link);
     }
   })
-  // app.on("open-url", (event, url) => {
-  //   event.preventDefault();
-  //   let mainWindow = BrowserWindow.getAllWindows()[0];
-  //   if (mainWindow) {
-  //     mainWindow.focus();
-  //   } else {
-  //     createWindow();
-  //     mainWindow = BrowserWindow.getAllWindows()[0];
-  //   }
-  //   // open the deep link in a new window using s3 browser
-  //   let deep_link = url.pop(); // full url with s3:// prefix
-  //   dialog.showMessageBox(mainWindow, {type: "info", message: `Opening ${url} in a new window.`});
-  //   openDeepLink(mainWindow, deep_link);
-  // });
-
-  // placed after open-url handler just in case and use another ready event handler
-  // app.on("ready", () => {
-  //   electron_utils.init_ipc_handlers();
-  //   createWindow();
-  // });
-
-  // Start app once electron has initialized
-  // app.whenReady().then(() => {
-  //   electron_utils.init_ipc_handlers();
-  //   createWindow();    
-  // });
 }
 
 function createWindow() {
@@ -111,6 +84,17 @@ function createWindow() {
   // Open the DevTools.
   if (isDev) {
     mainWindow.webContents.openDevTools({ mode: "detach" });
+  }
+  
+  if (process.platform === 'win32') {
+    // This handles opening a deep link when the app wasn't already running
+    let deep_link;
+    // process.argv will be a string or an array
+    typeof(process.argv) === "string" ? deep_link = process.argv : deep_link = process.argv.pop();
+    // ensure link starts with s3://
+    if (typeof(deep_link) === "string" && deep_link.startsWith(s3_protocol)) {
+      openDeepLink(mainWindow, deep_link);
+    }
   }
 }
 

--- a/react-frontend/public/electron.js
+++ b/react-frontend/public/electron.js
@@ -9,7 +9,7 @@ const isDev = require("electron-is-dev");
 
 // Only intercept s3 protocol if specified in config
 let config = JSON.parse(fs.readFileSync(path.resolve(__dirname,"./config-dup.json"), "utf-8"));
-if ("intercept_s3_protocol" in config) {
+if (config.app === "s3" && "intercept_s3_protocol" in config) {
   // https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
   if (process.defaultApp) {
     if (process.argv.length >= 2) {

--- a/react-frontend/public/electron_constants.js
+++ b/react-frontend/public/electron_constants.js
@@ -25,3 +25,14 @@ exports.image_types = {
     jpg: "jpg",
     png: "png",
 }
+
+// S3 Browser modes
+exports.s3_browser_modes = {
+    SELECT_DIRECTORY: "select_directory",
+    SELECT_IMG_DIRECTORY: "select_img_directory",
+    SELECT_JSON: "select_json",
+    SAVE_JSON: "save_json",
+    SELECT_IMAGE: "select_image",
+    SAVE_IMAGE: "save_image",
+    DEEP_LINK: "deep_link",
+}

--- a/react-frontend/public/electron_constants.js
+++ b/react-frontend/public/electron_constants.js
@@ -1,6 +1,16 @@
 // Constants. Be careful not to include imports in this file 
 // so that it can be used by the react frontend without issue.
 
+// List of valid components
+exports.components = {
+    GRID: "grid",
+    MULTI_CLASS_GRID: "multiclassgrid",
+    HOME: "home",
+    BINARY_EDITOR: "binaryeditor",
+    S3_BROWSER: "S3Browser",
+    IMAGE_LABELER: "imagelabeler"
+}
+
 // List of valid function name keys
 exports.function_names = {
     SAVE_BINARY_DIRECTORY: "saveBinaryDirectory",
@@ -36,3 +46,5 @@ exports.s3_browser_modes = {
     SAVE_IMAGE: "save_image",
     DEEP_LINK: "deep_link",
 }
+
+exports.s3_protocol = "s3" // followed by '://', e.g. 's3://'

--- a/react-frontend/public/electron_utils.js
+++ b/react-frontend/public/electron_utils.js
@@ -199,12 +199,12 @@ async function handleLoadImageDialog(event, data) {
  * Load images from a folder as base64 strings
  * 
  * @param {*} event event
- * @param {string} data file path
+ * @param {string} data {start_folder: <string>}
  * @returns {Object} image base64 strings indexed by image name
  */
 async function handleLoadImages(event, data) {
     try {
-        let file_path = data;
+        let file_path = data.start_folder;
         let files = fs.readdirSync(file_path);
         let images = {};
         files.forEach(file => {

--- a/react-frontend/public/electron_utils.js
+++ b/react-frontend/public/electron_utils.js
@@ -93,7 +93,7 @@ async function handleOpenFile(event, data) {
  * Open a directory selection dialog
  * 
  * @param {*} event event
- * @param {Object} data starting folder
+ * @param {Object} data {start_folder: <string>}
  * @returns dir path on sucess, nothing on cancel
  */
 async function handleOpenDirDialog(event, data) {
@@ -102,8 +102,8 @@ async function handleOpenDirDialog(event, data) {
         properties: ["openDirectory"]
     }
     // Start at data if it exists and is a non-empty string
-    if (data && typeof data === "string") {
-        dialogOptions["defaultPath"] = data;
+    if (data && "start_folder" in data) {
+        dialogOptions["defaultPath"] = data.start_folder;
     }
     const { canceled, filePaths } = await dialog.showOpenDialog(dialogOptions);
     if (canceled) {
@@ -119,7 +119,7 @@ async function handleOpenDirDialog(event, data) {
  * TODO: implement
  * 
  * @param {*} event event
- * @param {Object} data data
+ * @param {Object} data {start_folder: <string>}
  * @returns dir path on sucess, nothing on cancel
  */
 async function handleOpenImageDirDialog(event, data) {
@@ -175,7 +175,7 @@ async function handleGetFolderContents(event, data) {
  * TODO: implement
  * 
  * @param {*} event event
- * @param {Object} data data
+ * @param {Object} data {start_folder: <string>}
  */
 async function handleLoadImageDialog(event, data) {
     console.error("handleLoadImageDialog not implemented.");
@@ -240,7 +240,7 @@ async function handleSaveImageDialog(event, data) {
  * and then load and return the labels.
  * 
  * @param {*} event event
- * @param {Object} data data
+ * @param {Object} data {start_folder: <string>, loadnames: <Array[string]>]}
  * @returns {Object} labels
  */
 async function handleLoadJsonDialog(event, data) {
@@ -271,7 +271,7 @@ async function handleLoadJsonDialog(event, data) {
  * Open a save file dialog
  * 
  * @param event event
- * @param {object} data {labels: <Object>, path: <string>, savename: <string>}
+ * @param {object} data {labels: <Object>, start_folder: <string>, savename: <string>}
  * @returns file path on sucess, nothing on cancel
  */
 async function handleSaveJsonDialog(event, data) {
@@ -282,10 +282,10 @@ async function handleSaveJsonDialog(event, data) {
         ],
     }
     // Populate the default path
-    if ("path" in data && "savename" in data) {
+    if ("start_folder" in data && "savename" in data) {
         // Ensure savename is a non-empty string
         if (typeof data["savename"] === "string" && data["savename"] !== "") {
-            dialogOptions["defaultPath"] = path.join(data["path"], data["savename"]);
+            dialogOptions["defaultPath"] = path.join(data["start_folder"], data["savename"]);
         }
     }
     const { canceled, filePath } = await dialog.showSaveDialog(dialogOptions);
@@ -306,13 +306,13 @@ async function handleSaveJsonDialog(event, data) {
  * Save a json to a path
  * 
  * @param event event
- * @param {object} data {labels: <Object>, path: <string>}
+ * @param {object} data {labels: <Object>, start_folder: <string>}
  * @returns file path on sucess, nothing on cancel
  */
  async function handleSaveJson(event, data) {
     try {
-        fs.writeFileSync(data.path, JSON.stringify(data.labels));
-        return "Saved labels at " + data.path;
+        fs.writeFileSync(data.start_folder, JSON.stringify(data.labels));
+        return "Saved labels at " + data.start_folder;
     } catch (e) {
         return "Error when saving labels.";
     }

--- a/react-frontend/public/electron_utils.js
+++ b/react-frontend/public/electron_utils.js
@@ -86,6 +86,19 @@ async function handleOpenFile(event, data) {
 }
 
 
+/**
+ * get the file name and folder from a path
+ * 
+ * @param {string} path path to split
+ * @returns {Object} {file_name: <string>, folder: <string>}
+ */
+exports.getFileAndFolder = (path) =>  {
+    let file_name = path.split("/").slice(-1)[0];
+    let folder = path.replace(file_name, "");
+    return {file_name: file_name, folder: folder};
+}
+
+
 // ##### DIRECTORY #####
 
 

--- a/react-frontend/public/electron_utils.js
+++ b/react-frontend/public/electron_utils.js
@@ -115,7 +115,7 @@ async function handleOpenDirDialog(event, data) {
         properties: ["openDirectory"]
     }
     // Start at data if it exists and is a non-empty string
-    if (data && "start_folder" in data) {
+    if (data && "start_folder" in data && typeof data["start_folder"] === "string" && data["start_folder"] !== "") {
         dialogOptions["defaultPath"] = data.start_folder;
     }
     const { canceled, filePaths } = await dialog.showOpenDialog(dialogOptions);

--- a/react-frontend/src/App.js
+++ b/react-frontend/src/App.js
@@ -47,7 +47,7 @@ class App extends Component {
       component.QASM = this.QASM;
 
       // If the component is home the path will always be /
-      if (component.component === "home") {
+      if (component.component === components.HOME) {
         component.path = "/";
         this.home_component_present = true;
       }
@@ -85,7 +85,7 @@ class App extends Component {
 
   logoOnClick() {
     // Click on the home button to go to the home page
-    let link = document.getElementById("home-link");
+    let link = document.getElementById(components.HOME + "-link");
     link.click();
   }
 
@@ -114,16 +114,16 @@ class App extends Component {
             still create the link so that the icon can be pressed to reach it.*/}
             {!this.home_component_present &&
               <Link 
-                id="home-link"
+                id={components.HOME + "-link"}
                 className=" Link hidden"
                 to="/"
-                key="home"/>
+                key={components.HOME}/>
             }
             <Link 
-                id="s3browser-link"
+                id={components.S3_BROWSER + "-link"}
                 className=" Link hidden"
-                to="S3Browser"
-                key="S3Browser"/>
+                to={components.S3_BROWSER}
+                key={components.S3_BROWSER}/>
           </div>
         </div>
         <Routes>
@@ -138,13 +138,13 @@ class App extends Component {
           {!this.home_component_present &&
             <Route
               path="/"
-              element={COMPONENT_KEYS["home"]({QASM: this.QASM})}
-              key="home"/>
+              element={COMPONENT_KEYS[components.HOME]({QASM: this.QASM})}
+              key={components.HOME}/>
           }
           <Route 
-            path="S3Browser" 
-            element={COMPONENT_KEYS["S3Browser"](this.s3props)}
-            key="S3Browser"/>
+            path={components.S3_BROWSER} 
+            element={COMPONENT_KEYS[components.S3_BROWSER](this.s3props)}
+            key={components.S3_BROWSER}/>
         </Routes>
       </div>
       </MemoryRouter>

--- a/react-frontend/src/App.js
+++ b/react-frontend/src/App.js
@@ -11,14 +11,16 @@ import ImageLabeler from './components/ImageLabeler';
 import icon from "../public/icon.png";
 import {Link, MemoryRouter, Route, Routes} from "react-router-dom";
 
+const { components } = require("../public/electron_constants.js");
+
 // Link keys to components
 const COMPONENT_KEYS = {
-  "grid":           (props) => {return <Grid {...props}/>},
-  "multiclassgrid": (props) => {return <MultiClassGrid {...props}/>},
-  "home":           (props) => {return <Home {...props}/>},
-  "binaryeditor":   (props) => {return <BinaryEditors {...props}/>},
-  "S3Browser":      (props) => {return <S3Browser {...props}/>},
-  "imagelabeler":   (props) => {return <ImageLabeler {...props}/>},
+  [components.GRID]:             (props) => {return <Grid {...props}/>},
+  [components.MULTI_CLASS_GRID]: (props) => {return <MultiClassGrid {...props}/>},
+  [components.HOME]:             (props) => {return <Home {...props}/>},
+  [components.BINARY_EDITOR]:    (props) => {return <BinaryEditors {...props}/>},
+  [components.S3_BROWSER]:       (props) => {return <S3Browser {...props}/>},
+  [components.IMAGE_LABELER]:    (props) => {return <ImageLabeler {...props}/>},
 }
 
 class App extends Component {

--- a/react-frontend/src/QASM/constants.js
+++ b/react-frontend/src/QASM/constants.js
@@ -15,4 +15,5 @@ exports.s3_browser_modes = {
     SAVE_JSON: "save_json",
     SELECT_IMAGE: "select_image",
     SAVE_IMAGE: "save_image",
+    DEEP_LINK: "deep_link",
 }

--- a/react-frontend/src/QASM/constants.js
+++ b/react-frontend/src/QASM/constants.js
@@ -7,13 +7,3 @@ exports.local_paths = {
 exports.local_env = {
     API_URL: process.env.REACT_APP_API_URL,
 }
-
-exports.s3_browser_modes = {
-    SELECT_DIRECTORY: "select_directory",
-    SELECT_IMG_DIRECTORY: "select_img_directory",
-    SELECT_JSON: "select_json",
-    SAVE_JSON: "save_json",
-    SELECT_IMAGE: "select_image",
-    SAVE_IMAGE: "save_image",
-    DEEP_LINK: "deep_link",
-}

--- a/react-frontend/src/QASM/grid_utils.js
+++ b/react-frontend/src/QASM/grid_utils.js
@@ -413,8 +413,12 @@ export async function loadImageDir(window, component) {
  * @param {*} window window object
  * @param {*} component component that called this function: pass in `this`
  */
-export async function selectImageDir(window, component) {
-    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, {"start_folder": component.src});
+export async function selectImageDir(window, component, start_folder = undefined, bucket_name = undefined) {
+    let params = {
+        "start_folder": start_folder !== undefined ? start_folder : component.src,
+        "bucket_name": bucket_name,
+    }
+    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, params);
     if (dir_path !== undefined) {
         component.src = dir_path;
         await loadImageDir(window, component);

--- a/react-frontend/src/QASM/grid_utils.js
+++ b/react-frontend/src/QASM/grid_utils.js
@@ -61,6 +61,9 @@ export function updateState(component) {
  * @param {*} props component props
  */
 export function initProps(window, document, component, props) {
+    // Set component name in window
+    window.COMPONENT = component;
+    
     // Set global values used in event handlers
     WINDOW = window;
     DOCUMENT = document;
@@ -92,6 +95,10 @@ export function initProps(window, document, component, props) {
     component.autoload_labels_on_dir_select = props.autoload_labels_on_dir_select || false;
     component.image_layer_folder_names = props.image_layer_folder_names || undefined; // [Array[<string>], ...]
     component.labels = initLabels(component);
+
+    // Bind functions for deep links
+    component.selectImageDir = selectImageDir.bind(component);
+    component.loadLabels = loadLabels.bind(component);
     
     // Initialize keybinds
     init_keybinds(props, GRID_DEFAULT_KEYBINDS, GRID_KEYBINDS);
@@ -495,10 +502,10 @@ export function initLabels(component, labels = null) {
  * @param {*} component component that called this function: pass in `this`
  * @param {Array[string]} loadnames Array of filenames to try and autoload
  */
-export async function loadLabels(window, component, loadnames = undefined) {
+export async function loadLabels(window, component, loadnames = undefined, start_folder = undefined) {
     let params = {
-        // Start one folder up from the current directory
-        path: getOneFolderUp(component.src),
+        // Start at start_folder, or one folder up from the current directory
+        path: start_folder !== undefined ? start_folder : getOneFolderUp(component.src),
         // Try and load a specific file if loadnames is defined
         loadnames: loadnames,
     }

--- a/react-frontend/src/QASM/grid_utils.js
+++ b/react-frontend/src/QASM/grid_utils.js
@@ -414,7 +414,7 @@ export async function loadImageDir(window, component) {
  * @param {*} component component that called this function: pass in `this`
  */
 export async function selectImageDir(window, component) {
-    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, component.src);
+    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, {"start_folder": component.src});
     if (dir_path !== undefined) {
         component.src = dir_path;
         await loadImageDir(window, component);
@@ -502,10 +502,11 @@ export function initLabels(component, labels = null) {
  * @param {*} component component that called this function: pass in `this`
  * @param {Array[string]} loadnames Array of filenames to try and autoload
  */
-export async function loadLabels(window, component, loadnames = undefined, start_folder = undefined) {
+export async function loadLabels(window, component, loadnames = undefined, start_folder = undefined, bucket_name = undefined) {
     let params = {
         // Start at start_folder, or one folder up from the current directory
-        path: start_folder !== undefined ? start_folder : getOneFolderUp(component.src),
+        start_folder: start_folder !== undefined ? start_folder : getOneFolderUp(component.src),
+        bucket_name: bucket_name,
         // Try and load a specific file if loadnames is defined
         loadnames: loadnames,
     }
@@ -556,14 +557,17 @@ export function changeAutoLoadOnDirSelect(component) {
  * @param {*} window window object
  * @param {*} component component that called this function: pass in `this`
  * @param {string} savename filename to save labels to
+ * @param {string} start_folder folder to start in; defaults to one folder up from the current directory
+ * @param {string} bucket_name bucket name
  */
-export async function saveLabels(window, component, savename = "") {
+export async function saveLabels(window, component, savename = "", start_folder = undefined, bucket_name = undefined) {
     // Use label format of the current page
     component.updateLocalLabels();
     let params = {
         labels: component.labels,
         // Start one folder up from the current directory
-        path: getOneFolderUp(component.src),
+        start_folder: start_folder !== undefined ? start_folder : getOneFolderUp(component.src),
+        bucket_name: bucket_name,
         savename: savename,
     }
 
@@ -592,7 +596,7 @@ export function clearAllLabels(component) {
  */
 export async function addImageLayer(window, component) {
     // Prompt user to select directory
-    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, component.src);
+    let dir_path = await component.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, {"start_folder": component.src});
     console.log(dir_path);
 
     // Load images and add them to the image stack

--- a/react-frontend/src/QASM/lambda_handlers.js
+++ b/react-frontend/src/QASM/lambda_handlers.js
@@ -32,7 +32,7 @@ export { function_handlers }
  * Open a directory selection dialog
  *
  * @param {Object} QASM QASM object
- * @param {string} data starting folder
+ * @param {string} data {start_folder: <string>, bucket_name: <string>}
  * @param {*} window window
  * @returns s3 path on success, nothing on cancel
  */
@@ -40,7 +40,8 @@ async function handleOpenDirDialog(QASM, data, window) {
     let url = get_new_window_url(window, "s3Browser");
     let popup = window.open(url, "S3 Browser");
     popup.S3_BROWSER_MODE = s3_browser_modes.SELECT_DIRECTORY;
-    popup.START_FOLDER = data
+    popup.START_FOLDER = data.start_folder;
+    popup.BUCKET_NAME = data.bucket_name;
 
     return new Promise(resolve => window.onmessage = (e) => {
         try {
@@ -57,7 +58,7 @@ async function handleOpenDirDialog(QASM, data, window) {
  * only allows folders that contain images
  *
  * @param {Object} QASM QASM object
- * @param {string} data starting folder
+ * @param {string} data {start_folder: <string>, bucket_name: <string>}
  * @param {*} window window
  * @returns s3 path on success, nothing on cancel
  */
@@ -65,7 +66,8 @@ async function handleOpenDirDialog(QASM, data, window) {
     let url = get_new_window_url(window, "s3Browser");
     let popup = window.open(url, "S3 Browser");
     popup.S3_BROWSER_MODE = s3_browser_modes.SELECT_IMG_DIRECTORY;
-    popup.START_FOLDER = data
+    popup.START_FOLDER = data.start_folder;
+    popup.BUCKET_NAME = data.bucket_name;
 
     return new Promise(resolve => window.onmessage = (e) => {
         try {
@@ -121,7 +123,7 @@ async function handleGetFolderContents(QASM, data, window) {
 /**
  * Get url for a single image
  * @param {Object} QASM QASM object
- * @param {string} data starting folder
+ * @param {string} data {start_folder: <string>, bucket_name: <string>}
  * @param {*} window window
  * @returns {*} image url
  */
@@ -129,13 +131,14 @@ async function handleLoadImageDialog(QASM, data, window) {
     let url = get_new_window_url(window, "s3Browser");
     let popup = window.open(url, "S3 Browser");
     popup.S3_BROWSER_MODE = s3_browser_modes.SELECT_IMAGE;
-    popup.START_FOLDER = data
+    popup.START_FOLDER = data.start_folder;
+    popup.BUCKET_NAME = data.bucket_name;
 
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
                 let params = {
-                    bucket_name: QASM.s3_bucket,
+                    bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,
                 }
                 let res = await api_consolidator_error_handler(params, "load_image");
@@ -219,23 +222,23 @@ async function handleSaveImageDialog(QASM, data, window) {
  * and then load and return the labels.
  * 
  * @param {Object} QASM QASM object
- * @param {string} data starting folder
+ * @param {string} data {start_folder: <string>, bucket_name: <string>, loadnames: <Array[string]>]}
  * @param {*} window window
  * @returns {Object} labels
  */
 async function handleLoadJsonDialog(QASM, data, window) {
     let url = get_new_window_url(window, "s3Browser");
     let popup = window.open(url, "S3 Browser");
-    // TODO: different mode for loading/saving?
     popup.S3_BROWSER_MODE = s3_browser_modes.SELECT_JSON; 
-    popup.START_FOLDER = data.path;
+    popup.START_FOLDER = data.start_folder;
+    popup.BUCKET_NAME = data.bucket_name;
     popup.LOADNAMES = data.loadnames;
 
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
                 let params = {
-                    bucket_name: QASM.s3_bucket,
+                    bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,
                 }
                 let res = await api_consolidator_error_handler(params, "load_labels");
@@ -272,7 +275,7 @@ async function handleLoadJson(QASM, data, window) {
  * and then save the labels.
  * 
  * @param {Object} QASM QASM object
- * @param {Object} data {labels: {}, path: "", savename: ""}
+ * @param {Object} data {labels: <Object>, start_folder: <string>, bucket_name: <string>, savename: <string>}
  * @param {*} window window
  * @returns {string} result
  */
@@ -280,14 +283,15 @@ async function handleSaveJsonDialog(QASM, data, window) {
     let url = get_new_window_url(window, "s3Browser");
     let popup = window.open(url, "S3 Browser");
     popup.S3_BROWSER_MODE = s3_browser_modes.SAVE_JSON;
-    popup.START_FOLDER = data.path;
+    popup.START_FOLDER = data.start_folder;
+    popup.BUCKET_NAME = data.bucket_name;
     popup.DEFAULT_SAVENAME = data.savename;
 
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
                 let params = {
-                    bucket_name: QASM.s3_bucket,
+                    bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,
                     labels: data.labels,
                 }
@@ -304,15 +308,15 @@ async function handleSaveJsonDialog(QASM, data, window) {
  * Save data to the specified path.
  * 
  * @param {Object} QASM QASM object
- * @param {Object} data {labels: {}, path: ""}
+ * @param {Object} data {labels: <Object>, start_folder: <string>, bucket_name: <string>}
  * @param {*} window window
  * @returns {string} result
  */
  async function handleSaveJson(QASM, data, window) {
     try { 
         let params = {
-            bucket_name: QASM.s3_bucket,
-            file_name: data.path,
+            bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
+            file_name: data.start_folder,
             labels: data.labels,
         }
         await api_consolidator_error_handler(params, "save_labels");

--- a/react-frontend/src/QASM/lambda_handlers.js
+++ b/react-frontend/src/QASM/lambda_handlers.js
@@ -46,6 +46,7 @@ async function handleOpenDirDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 resolve(e.data.path);
             }
         } catch {}
@@ -72,6 +73,7 @@ async function handleOpenDirDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 resolve(e.data.path);
             }
         } catch {}
@@ -137,6 +139,7 @@ async function handleLoadImageDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 let params = {
                     bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,
@@ -200,6 +203,7 @@ async function handleSaveImageDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 let params = {
                     bucket_name: QASM.s3_bucket,
                     file_name: e.data.path,
@@ -237,6 +241,7 @@ async function handleLoadJsonDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 let params = {
                     bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,
@@ -290,6 +295,7 @@ async function handleSaveJsonDialog(QASM, data, window) {
     return new Promise(resolve => window.onmessage = async (e) => {
         try {
             if (e.data.success) {
+                QASM.s3_bucket = e.data.bucket_name;
                 let params = {
                     bucket_name: data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
                     file_name: e.data.path,

--- a/react-frontend/src/QASM/lambda_handlers.js
+++ b/react-frontend/src/QASM/lambda_handlers.js
@@ -156,14 +156,14 @@ async function handleLoadImageDialog(QASM, data, window) {
  * Get signed urls for all images in an s3 folder
  * 
  * @param {Object} QASM QASM object
- * @param {string} data full s3 path
+ * @param {string} data {start_folder: <string>, bucket_name: <string>}
  * @param {*} window window
  * @returns {Object} { image_name: signed_url } 
  */
 async function handleLoadImages(QASM, data, window) {
     let params = {
-        "bucket_name": QASM.s3_bucket,
-        "folder_name": data
+        "bucket_name": data.bucket_name !== undefined ? data.bucket_name : QASM.s3_bucket,
+        "folder_name": data.start_folder
     }
     let res = await api_consolidator_error_handler(params, "get_signed_urls_in_folder");
     return res.urls;

--- a/react-frontend/src/QASM/lambda_handlers.js
+++ b/react-frontend/src/QASM/lambda_handlers.js
@@ -1,7 +1,6 @@
 const { api_consolidator_error_handler } = require("./api_utils.js");
 const { get_new_window_url } = require("./utils.js");
-const { function_names } = require("../../public/electron_constants.js");
-const { s3_browser_modes } = require("./constants.js");
+const { function_names, s3_browser_modes } = require("../../public/electron_constants.js");
 
 // Export like this so static site works idk why
 const function_handlers = {

--- a/react-frontend/src/components/BinaryEditors.js
+++ b/react-frontend/src/components/BinaryEditors.js
@@ -9,6 +9,9 @@ import S3DirectoryBinaryEditor from "./S3DirectoryBinaryEditor";
 class BinaryEditors extends Component {
     constructor(props) {
         super(props);
+        // Expose component in window
+        window.COMPONENT = this;
+        
         this.props = props;
         this.mode = props.mode;
     }

--- a/react-frontend/src/components/Home.js
+++ b/react-frontend/src/components/Home.js
@@ -4,6 +4,8 @@ import icon from "../../public/icon.png";
 class Home extends Component {
     constructor(props) {
         super(props);
+        // Expose component in window
+        window.COMPONENT = this;
 
         // Initialize props
         this.QASM = props.QASM;

--- a/react-frontend/src/components/Home.js
+++ b/react-frontend/src/components/Home.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import icon from "../../public/icon.png";
+const { components } = require("../../public/electron_constants.js");
 
 class Home extends Component {
     constructor(props) {
@@ -30,7 +31,7 @@ class Home extends Component {
     forwardToS3Browser() {
         // Hack to get to s3 browser using memory router
         if (window.S3_BROWSER_MODE !== undefined) {
-            let link = document.getElementById("s3browser-link");
+            let link = document.getElementById(components.S3_BROWSER + "-link");
             link.click();
         }
     }

--- a/react-frontend/src/components/ImageLabeler.js
+++ b/react-frontend/src/components/ImageLabeler.js
@@ -19,6 +19,8 @@ class ImageLabeler extends Component {
 
     constructor(props) {
         super(props);
+        // Expose component in window
+        window.COMPONENT = this;
 
         // Initialize props
         this.QASM      = props.QASM;

--- a/react-frontend/src/components/ImageLabeler.js
+++ b/react-frontend/src/components/ImageLabeler.js
@@ -106,7 +106,7 @@ class ImageLabeler extends Component {
     }
 
     async selectImageDir() {
-        let res = await this.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, this.image_dir); // prompt selection
+        let res = await this.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, {"start_folder": this.image_dir}); // prompt selection
         if (res !== null) {
             this.image_dir = res;
             this.loadImageDir();
@@ -114,7 +114,7 @@ class ImageLabeler extends Component {
     }
 
     async selectAnnoDir() {
-        let res = await this.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, this.anno_dir); // prompt selection
+        let res = await this.QASM.call_backend(window, function_names.OPEN_DIR_DIALOG, {"start_folder": this.anno_dir}); // prompt selection
         if (res !== null) {
             this.anno_dir = res;
             await this.loadAnnotations();
@@ -155,7 +155,7 @@ class ImageLabeler extends Component {
         if (this.anno_filename !== null) {
             let params = {
                 labels: {},
-                path: this.anno_filename,
+                start_folder: this.anno_filename,
             }
             console.log(annotations);
             let resume_from_key

--- a/react-frontend/src/components/ImageLabeler.js
+++ b/react-frontend/src/components/ImageLabeler.js
@@ -88,7 +88,7 @@ class ImageLabeler extends Component {
         if (this.image_dir !== null) {
             // Create a dictionary for every image in the directory where the image name is
             // the key and the path is the value
-            this.images = await this.QASM.call_backend(window, function_names.LOAD_IMAGES, this.image_dir);
+            this.images = await this.QASM.call_backend(window, function_names.LOAD_IMAGES, {"start_folder": this.image_dir});
 
             // Create a list of keys
             this.images_keys = Object.keys(this.images).sort();
@@ -126,6 +126,15 @@ class ImageLabeler extends Component {
         }
     }
 
+    /**
+     * Handler for when the user opens a deep link
+     * to a directory. The user will be prompted to
+     * select whether the directory contains images
+     * or annotations.
+     * 
+     * @param {string} start_folder folder to start in
+     * @param {string} bucket_name name of s3 bucket
+     */
     selectDirType(start_folder, bucket_name) {
         /* eslint-disable */
         // Prompt user to select image or annotation directory

--- a/react-frontend/src/components/ImageLabeler.js
+++ b/react-frontend/src/components/ImageLabeler.js
@@ -60,6 +60,7 @@ class ImageLabeler extends Component {
         this.loadImageDir     = this.loadImageDir.bind(this);
         this.selectImageDir   = this.selectImageDir.bind(this);
         this.selectAnnoDir    = this.selectAnnoDir.bind(this);
+        this.selectDirType    = this.selectDirType.bind(this);
         this.loadAnnotations  = this.loadAnnotations.bind(this);
         this.changeCurImage   = this.changeCurImage.bind(this);
         this.on_submit        = this.on_submit.bind(this);
@@ -122,6 +123,38 @@ class ImageLabeler extends Component {
         if (res !== null) {
             this.anno_dir = res;
             await this.loadAnnotations();
+        }
+    }
+
+    selectDirType(start_folder, bucket_name) {
+        /* eslint-disable */
+        // Prompt user to select image or annotation directory
+        let load_image_dir = confirm("Load " + bucket_name + "/" + start_folder + " as image directory?");
+        let load_anno_dir = false;
+        if (!load_image_dir) {
+            load_anno_dir = confirm("Load " + bucket_name + "/" + start_folder + " as annotation directory?");
+        }
+
+        // If either is true, then load the directory
+        if (load_image_dir || load_anno_dir) {
+            // Confirm switching buckets if necessary
+            if (bucket_name !== undefined && bucket_name !== this.QASM.s3_bucket) {
+                if (confirm("Proceed and switch from bucket " + this.QASM.s3_bucket + " to bucket: " + bucket_name + "?")) {
+                    this.QASM.s3_bucket = bucket_name;
+                } else {
+                    console.log("Canceled directory selection.");
+                    return;
+                }
+            }
+
+            // Load the directory
+            if (load_image_dir) {
+                this.image_dir = start_folder;
+                this.loadImageDir();
+            } else {
+                this.anno_dir = start_folder;
+                this.loadAnnotations();
+            }
         }
     }
 

--- a/react-frontend/src/components/S3Browser.js
+++ b/react-frontend/src/components/S3Browser.js
@@ -3,8 +3,7 @@ import Dropdown from "./Dropdown.js";
 import S3Folder from "./S3Folder.js";
 import S3File from "./S3File.js";
 import "../css/S3Browser.css";
-const { image_types, function_names } = require("../../public/electron_constants.js");
-const { s3_browser_modes } = require("../QASM/constants.js");
+const { image_types, function_names, s3_browser_modes } = require("../../public/electron_constants.js");
 const BASE_PATH = "" // Key used to represent the root folder of the bucket
 
 class S3Browser extends Component {

--- a/react-frontend/src/components/S3Browser.js
+++ b/react-frontend/src/components/S3Browser.js
@@ -36,6 +36,8 @@ class S3Browser extends Component {
         } else if (this.bucket === undefined) {
             // Populate current bucket in cache
             this.addToCache(BASE_PATH, this.QASM.folders, this.QASM.files); 
+            // Set bucket name to current bucket
+            this.bucket = this.QASM.s3_bucket;
         }
 
         if (this.path == null) { // Starting at bucket level

--- a/react-frontend/src/components/S3Browser.js
+++ b/react-frontend/src/components/S3Browser.js
@@ -18,10 +18,24 @@ class S3Browser extends Component {
         this.QASM    = props.QASM;
         this.mode    = window.S3_BROWSER_MODE; // Set by window opener
         this.path    = window.START_FOLDER;
+        this.bucket  = window.BUCKET_NAME;
         this.default_savename = window.DEFAULT_SAVENAME;
         this.loadnames = window.LOADNAMES;
         this.parents = props.parents || []; // Stack of parent folders
-        this.addToCache(BASE_PATH, this.QASM.folders, this.QASM.files); // Always populate bucket in cache
+
+        if (this.bucket !== undefined && this.bucket !== this.QASM.s3_bucket) {
+            // Prompt user to switch buckets
+            if (window.confirm("Proceed and switch from bucket " + this.QASM.s3_bucket + " to bucket: " + this.bucket + "?")) {
+                this.QASM.s3_bucket = this.bucket;
+                this.QASM.files = [];
+                this.QASM.folders = [];
+            } else {
+                window.close();
+            }
+        } else if (this.bucket === undefined) {
+            // Populate current bucket in cache
+            this.addToCache(BASE_PATH, this.QASM.folders, this.QASM.files); 
+        }
 
         if (this.path == null) { // Starting at bucket level
             this.path = BASE_PATH

--- a/react-frontend/src/components/S3Browser.js
+++ b/react-frontend/src/components/S3Browser.js
@@ -13,6 +13,8 @@ class S3Browser extends Component {
     cache = {};
     constructor(props) {
         super(props);
+        // Expose component in window
+        window.COMPONENT = this;
         
         this.QASM    = props.QASM;
         this.mode    = window.S3_BROWSER_MODE; // Set by window opener

--- a/react-frontend/src/components/S3Browser.js
+++ b/react-frontend/src/components/S3Browser.js
@@ -155,6 +155,7 @@ class S3Browser extends Component {
         let data = {
             success: true,
             path: this.path,
+            bucket_name: this.bucket,
         }
         // Send data back to parent window
         window.opener.postMessage(data, '*');
@@ -224,6 +225,7 @@ class S3Browser extends Component {
             let data = {
                 success: true,
                 path: file,
+                bucket_name: this.bucket,
             }
             // Send data back to parent window
             window.opener.postMessage(data, '*');

--- a/react-frontend/uninstaller.nsh
+++ b/react-frontend/uninstaller.nsh
@@ -1,0 +1,6 @@
+!macro customUnInstall
+    SetRegView 64
+     DeleteRegKey HKCR "s3"
+    SetRegView 32
+     DeleteRegKey HKCR "s3"
+ !macroend


### PR DESCRIPTION
# S3 Deep Links
## What?
- Added `intercept_s3_protocol` as a top-level option in the config, which allows the user to specify which components should be allowed to handle redirects from `s3://` links.
- When enabled, navigating to an `s3://` link in a browser will automatically prompt the user to open the link in QASM. Depending on the active screen in the app, the link will then be passed to the component and loaded
- For `grid` and `multiclassgrid`, links will be loaded as labels if they end in `.json`, else they will try and be automatically loaded as an image directory.
- For `imagelabeler`, links will be loaded as a label if they end in `.json`, an image if they end in `.png` or `.jpg`, or will prompt the user to select whether to load a folder as an image directory or annotation directory.
- To test, add the following to the demo config:
```js
"intercept_s3_protocol": [
    "grid",
    "multiclassgrid",
    "imagelabeler"
],
```
and try navigating to a link like `s3://qasm-demo/grid-data/demo-1/images/`
- Also added some `package.json` fields bc I was sick of `electron-builder` complaining
## Why?
- @joshua-dean suggested the feature and pointed me to [this](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app) in the electron docs.
- This is one step towards having an upgraded, standalone S3 Browser component that can load an s3 link, and also provide basic functionality like downloading, previewing, uploading, etc.
## Checks:
- [x] Merged latest master
- [x] Tested relevant changes in all backend modes [local, s3]
- [x] Tested relevant changes in all frontend modes [locally, .exe, static site]
- [x] Ran `npm run qasm-push -- --config_path "./default-config.json"` to update the Demo site
- [x] Updated README.md (if needed)
- [x] Changed version number in react-frontend/package.json (if needed)
## Breaking Changes
To ensure that the protocol is properly removed on uninstall, a custom uninstall script had to be added. This seems to cause some collisions when trying to run `qasm-build` for an app that is already installed locally, and so existing apps with the same name must first be properly uninstalled using the app's uninstaller.