### PR TITLE
Fix/force-redirect

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "weeds-ulabel-demo",
-  "version": "0.19.0",
+  "name": "qasm-demo",
+  "version": "0.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16111,11 +16111,13 @@
       }
     },
     "ulabel": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/ulabel/-/ulabel-0.6.12.tgz",
-      "integrity": "sha512-m+nL68EPKijZ570phITrRXbLo1+aTjaU/mmXtRjvnDsWi/ybAe4wgE02lzw+A50i6GO7NOmd4mA6hg7hRW/XXA==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/ulabel/-/ulabel-0.10.8.tgz",
+      "integrity": "sha512-ZZ2w+YIukW20xnGgHmYhrPxr8zzehCRTV1LP2pSR/LHvDEt6qimvLRavRW8eYksvJZnIO81XXwCM71OwQqLXYQ==",
       "requires": {
+        "@turf/turf": "^6.5.0",
         "jquery": "^3.5.1",
+        "polygon-clipping": "^0.15.7",
         "uuidv4": "^6.2.6"
       }
     },

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "weeds-ulabel-demo",
+  "name": "qasm-demo",
   "author": {
     "name": "Trevor Burgoyne",
     "url": "https://github.com/TrevorBurgoyne"
@@ -15,7 +15,7 @@
     }
   ],
   "description": "A web application built on React and Electron, for running custom QA and labeling jobs from a local host, a packaged windows .exe, or a statically hosted S3 website.",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "proxy": "http://localhost:3000",
   "homepage": "./",
@@ -36,7 +36,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
-    "ulabel": "^0.6.12",
+    "ulabel": "^0.10.8",
     "util": "^0.12.4",
     "wait-on": "^6.0.1",
     "web-vitals": "^2.1.4",
@@ -79,7 +79,7 @@
     ]
   },
   "build": {
-    "productName": "Weeds ULabel Demo",
+    "productName": "QASM Demo",
     "win": {
       "target": "NSIS",
       "icon": "public/icon.png"

--- a/react-frontend/src/components/Ulabel.js
+++ b/react-frontend/src/components/Ulabel.js
@@ -141,15 +141,8 @@ class Ulabel extends Component {
     }
 
     componentWillUnmount() {
-        // This is a hack to force the page to reload
-        // when ulabel needs to be destroyed, such as 
-        // when navigating to a new page. Otherwise, 
-        // multiple layers of ulabel hooks build up in 
-        // the app which causes some wacky stuff to happen.
-
-        // TODO: With MemoryRouter this will always go back to homepage,
-        // when it should ideally reload the target component
-        window.location.reload(); 
+        // Remove ulabel's listeners
+        this.ulabel.remove_listeners();
     }
 }
 


### PR DESCRIPTION
# Fix/force-redirect
## What?
- Use the new `ulabel.remove_listeners()` method instead of force reloading
## Why?
- @csolbs24's new changes mean we can discard my old hacky approach of force reloading, which was not ideal at all.
## Checks:
- [x] Merged latest master
- [x] Tested relevant changes in all backend modes [local, s3]
- [x] Tested relevant changes in all frontend modes [locally, .exe, static site]
- [x] Ran `npm run qasm-push -- --config_path "./default-config.json"` to update the Demo site
- [x] Updated README.md (if needed)
- [x] Changed version number in react-frontend/package.json (if needed)
## Breaking Changes